### PR TITLE
Added analysis feature

### DIFF
--- a/Analyzer.cs
+++ b/Analyzer.cs
@@ -1,0 +1,119 @@
+﻿// <copyright file="Analyzer.cs" company="Windower Team">
+// Copyright © 2017 Windower Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ResourceExtractor
+{
+    internal static class Analyzer
+    {
+        internal static void Analyze(IEnumerable<KeyValuePair<string, dynamic>> model)
+        {
+            var rootPath = "analysis";
+            Directory.CreateDirectory(rootPath);
+            foreach (var pair in model)
+            {
+                var namePath = Path.Combine(rootPath, pair.Key);
+                Directory.CreateDirectory(namePath);
+                foreach (var property in Extract((IEnumerable<dynamic>) pair.Value, pair.Key))
+                {
+                    using (var file = File.Open(Path.Combine(namePath, $"{property.Key.Substring(1)}.lua"), FileMode.Create))
+                    using (var writer = new StreamWriter(file))
+                    {
+                        writer.WriteLine("return {");
+
+                        foreach (var bucket in property.Value.OrderBy(bucket => bucket.Key))
+                        {
+                            var names = bucket.Value.Select(obj => MakeValue(obj.en));
+                            if (bucket.Value.Count <= 5)
+                            {
+                                writer.WriteLine($"    [{MakeValue(bucket.Key)}] = {{{string.Join(", ", names)}}}");
+                            }
+                            else
+                            {
+                                writer.WriteLine($"    [{MakeValue(bucket.Key)}] = {{");
+                                foreach (var name in names)
+                                {
+                                    writer.WriteLine($"        {name},");
+                                }
+                                writer.WriteLine("    },");
+                            }
+                        }
+
+                        writer.WriteLine("}");
+                    }
+                }
+            }
+        }
+
+        internal static IDictionary<string, IDictionary<dynamic, ISet<dynamic>>> Extract(IEnumerable<dynamic> dict, string resName)
+        {
+            var properties = new Dictionary<string, IDictionary<dynamic, ISet<dynamic>>>();
+            foreach (var obj in dict)
+            {
+                foreach (var attribute in obj)
+                {
+                    if (!Program.IsValidObject(resName, obj))
+                    {
+                        continue;
+                    }
+
+                    var name = (string) attribute.Key;
+                    if (!name.StartsWith("_"))
+                    {
+                        continue;
+                    }
+
+                    if (!properties.ContainsKey(name))
+                    {
+                        properties[name] = new Dictionary<dynamic, ISet<dynamic>>();
+                    }
+
+                    var property = properties[name];
+
+                    var value = attribute.Value;
+                    if (!property.ContainsKey(value))
+                    {
+                        property[value] = new HashSet<dynamic>();
+                    }
+
+                    property[value].Add(obj);
+                }
+            }
+
+            return properties;
+        }
+
+        private static string MakeValue(dynamic value)
+        {
+            if (value is string || value is Enum)
+            {
+                return "\"" + value.ToString().Replace("\"", "\\\"").Replace("\n", "\\n") + "\"";
+            }
+
+            return FormattableString.Invariant($"{value}");
+        }
+    }
+}

--- a/DMsgStringList.cs
+++ b/DMsgStringList.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DMsgStringList.cs" company="Windower Team">
-// Copyright © 2013-2014 Windower Team
+// Copyright © 2013-2017 Windower Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -31,16 +31,16 @@ namespace ResourceExtractor
 
     internal class DMsgStringList : IList<IList<object>>
     {
-        private IList<object>[] objects;
+        private readonly IList<object>[] objects;
 
         internal DMsgStringList(Stream stream)
         {
             if (stream == null)
             {
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
             }
 
-            Header header = stream.Read<Header>(0);
+            var header = stream.Read<Header>(0);
 
             if (header.Format != 0x00000067736D5F64)
             {
@@ -183,21 +183,15 @@ namespace ResourceExtractor
             }
         }
 
-        bool ICollection<IList<object>>.IsReadOnly
-        {
-            get { return true; }
-        }
+        bool ICollection<IList<object>>.IsReadOnly => true;
 
-        public int Count
-        {
-            get { return objects.Length; }
-        }
+        public int Count => objects.Length;
 
         public IList<object> this[int index]
         {
-            get { return objects[index]; }
+            get => objects[index];
 
-            set { throw new NotSupportedException(); }
+            set => throw new NotSupportedException();
         }
 
         int IList<IList<object>>.IndexOf(IList<object> item)
@@ -264,45 +258,14 @@ namespace ResourceExtractor
             private int datasize;
             private int count;
 
-            public long Format
-            {
-                get { return format; }
-            }
-
-            public bool Encrypted
-            {
-                get { return encrypted != 0; }
-            }
-
-            public long Version
-            {
-                get { return version; }
-            }
-
-            public uint HeaderSize
-            {
-                get { return headersize; }
-            }
-
-            public uint TableSize
-            {
-                get { return tablesize; }
-            }
-
-            public uint EntrySize
-            {
-                get { return entrysize; }
-            }
-
-            public int DataSize
-            {
-                get { return datasize; }
-            }
-
-            public int Count
-            {
-                get { return count; }
-            }
+            public long Format => format;
+            public bool Encrypted => encrypted != 0;
+            public long Version => version;
+            public uint HeaderSize => headersize;
+            public uint TableSize => tablesize;
+            public uint EntrySize => entrysize;
+            public int DataSize => datasize;
+            public int Count => count;
         }
     }
 }

--- a/MapParser.cs
+++ b/MapParser.cs
@@ -1,5 +1,5 @@
-﻿// <copyright file="MapDats.cs" company="Windower Team">
-// Copyright © 2014 Windower Team
+﻿// <copyright file="MapParser.cs" company="Windower Team">
+// Copyright © 2014-2017 Windower Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -22,7 +22,6 @@
 
 namespace ResourceExtractor
 {
-    using System;
     using System.Collections.Generic;
     using System.Drawing.Imaging;
     using System.Globalization;
@@ -50,27 +49,16 @@ namespace ResourceExtractor
         //"205": {"18": 5685                    //18 is not used in game.
         //"226": {"0": 5475},                   //0 is a dummy map.
         //"242": {"0": 5490},                   //0 is a dummy map.
-        #endregion JSON Comments/Posterity
+        #endregion
 
         public static void Extract()
         {
-            Console.Write("Extract map data? (y/n) ");
-            Console.CursorVisible = true;
-            var Key = Console.ReadKey();
-            Console.CursorVisible = false;
-            Console.Write("\n");
-
-            if (Key.KeyChar != 'y')
-            {
-                return;
-            }
-
             Program.DisplayMessage("Extracting map data...");
 
             var Serializer = new JavaScriptSerializer();
             var DatLut = Serializer.Deserialize<IDictionary<string, IDictionary<string, ushort>>>(File.ReadAllText("MapDats.json"));
 
-            bool Success = false;
+            var Success = false;
             try
             {
                 foreach (var ZonePair in DatLut)
@@ -80,10 +68,10 @@ namespace ResourceExtractor
                     {
                         var Map = MapPair.Key;
 
-                        using (FileStream Stream = File.Open(Program.GetPath(MapPair.Value), FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                        using (var Stream = File.Open(Program.GetPath(MapPair.Value), FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                         {
                             var Image = ImageParser.Parse(Stream, true);
-                            using (FileStream OutFile = File.Open(string.Format(CultureInfo.InvariantCulture, "resources/maps/{0}_{1}.png", Zone, Map), FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite))
+                            using (var OutFile = File.Open(string.Format(CultureInfo.InvariantCulture, "resources/maps/{0}_{1}.png", Zone, Map), FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite))
                             {
                                 Image.Save(OutFile, ImageFormat.Png);
                             }

--- a/ModelObject.cs
+++ b/ModelObject.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ModelObject.cs" company="Windower Team">
-// Copyright © 2014 Windower Team
+// Copyright © 2014-2017 Windower Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -31,7 +31,7 @@ namespace ResourceExtractor
     [Serializable]
     internal class ModelObject : DynamicObject, ISerializable, IEnumerable<KeyValuePair<string, object>>
     {
-        private IDictionary<string, object> map = new Dictionary<string, object>();
+        private readonly IDictionary<string, object> map = new Dictionary<string, object>();
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
         public override bool TryGetMember(GetMemberBinder binder, out object result)
@@ -152,7 +152,7 @@ namespace ResourceExtractor
         {
             if (info == null)
             {
-                throw new ArgumentNullException("info");
+                throw new ArgumentNullException(nameof(info));
             }
 
             foreach (var pair in map)

--- a/Program.cs
+++ b/Program.cs
@@ -573,10 +573,6 @@ namespace ResourceExtractor
             {
 #endif
                 var xml = new XDocument(new XDeclaration("1.0", "utf-8", null), new XElement(name));
-                if (xml.Root == null)
-                {
-                    throw new InvalidDataException("fixes.xml file corrupted.");
-                }
                 var lua = new LuaFile(name);
 
                 foreach (var obj in model[name])
@@ -590,6 +586,10 @@ namespace ResourceExtractor
                     foreach (var pair in obj)
                     {
                         //TODO: Level dictionaries are currently messed up on XML output
+                        if (pair.Key.StartsWith("_"))
+                        {
+                            continue;
+                        }
                         xmlelement.SetAttributeValue(pair.Key, pair.Value);
                     }
 

--- a/Resource Extractor.csproj
+++ b/Resource Extractor.csproj
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbilityType.cs" />
+    <Compile Include="Analyzer.cs" />
     <Compile Include="ATParser.cs" />
     <Compile Include="BitmapParser.cs" />
     <Compile Include="DatParser.cs" />

--- a/Serializers/Lua/LuaAttribute.cs
+++ b/Serializers/Lua/LuaAttribute.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="LuaAttribute.cs" company="Windower Team">
-// Copyright © 2013-2014 Windower Team
+// Copyright © 2013-2017 Windower Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Linq;
 
 namespace ResourceExtractor.Serializers.Lua
@@ -37,9 +36,9 @@ namespace ResourceExtractor.Serializers.Lua
             Value = value;
         }
 
-        private string Key { get; set; }
+        private string Key { get; }
 
-        private object Value { get; set; }
+        private object Value { get; }
 
         public override string ToString()
         {

--- a/Serializers/Lua/LuaElement.cs
+++ b/Serializers/Lua/LuaElement.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="LuaElement.cs" company="Windower Team">
-// Copyright © 2013-2014 Windower Team
+// Copyright © 2013-2017 Windower Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -60,11 +60,11 @@ namespace ResourceExtractor.Serializers.Lua
             }
         }
 
-        public HashSet<string> Keys { get; private set; }
+        public HashSet<string> Keys { get; }
 
-        public int ID { get; private set; }
+        public int ID { get; }
 
-        private List<LuaAttribute> Attributes { get; set; }
+        private List<LuaAttribute> Attributes { get; }
 
         public override string ToString()
         {

--- a/Serializers/Lua/LuaElement.cs
+++ b/Serializers/Lua/LuaElement.cs
@@ -47,6 +47,10 @@ namespace ResourceExtractor.Serializers.Lua
             var otherKeys = new List<string>();
             foreach (var pair in obj)
             {
+                if (pair.Key.StartsWith("_"))
+                {
+                    continue;
+                }
                 otherKeys.Add(pair.Key);
             }
             foreach (var key in otherKeys.Where(key => !FixedKeys.Contains(key)).OrderBy(key => key))

--- a/Serializers/Lua/LuaFile.cs
+++ b/Serializers/Lua/LuaFile.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="LuaFile.cs" company="Windower Team">
-// Copyright © 2013-2014 Windower Team
+// Copyright © 2013-2017 Windower Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -37,11 +37,11 @@ namespace ResourceExtractor.Serializers.Lua
             Keys = new HashSet<string>();
         }
 
-        private string Name { get; set; }
+        private string Name { get; }
 
-        private List<LuaElement> Elements { get; set; }
+        private List<LuaElement> Elements { get; }
 
-        private HashSet<string> Keys { get; set; }
+        private HashSet<string> Keys { get; }
 
         public void Add(dynamic e)
         {


### PR DESCRIPTION
Added a feature to analyse unknown/unsure fields. Here's how it works:

Add an underscore to a field name, and it won't be written to the resources by default. I added some such fields for spells, here's an example:
```c#
            spell._aoe_range = reader.ReadByte(); // spell.aoe_range : 11 for uncastable AOE enfeebling. 15 for self target spells
```

This field will now not appear in the resources that are produced when RE runs. But if any such fields are present, the analyzer will pick up on it and start some common analysis methods to help figure out a field's meaning.

To invoke the analyzer, start RE with `--analyze` or `-a`. Then it will start processing any field that starts with an underscore and will try to find similarities between objects with the same value for that field. It will save its output in the "analysis" folder. For example, if you run it for spells with the above mentioned `_cursor_behavior`, it will produce [this file](https://gist.github.com/z16/a9780fb2b7bc0883b8b404ba5eece3b1) as result. The file itself is in a Lua format for easy loading in a Windower script, since it's easily readable and in case someone wants to write more sophisticated analyses using Lua, which also enables people to use the other resources.

The file itself shows all objects that share a value of that unknown field, as well as other fields they have in common. This may help find more similarities between the two.