### PR TITLE
adding dispel +1 message

### DIFF
--- a/fixes.xml
+++ b/fixes.xml
@@ -2477,7 +2477,7 @@ IN THE SOFTWARE.
       <o id="770" en="Skillchain: Umbra.${lb}${target} recovers ${number} hit points!" color="H" />
       <o id="771" en="Congratulations! Your deeds of valor will ring throughout the ages, providing inspiration for generations to come." color="1" />
       <o id="772" en="${actor} stands resolute thanks to the power of the bonds that tie you!" color="1" />
-      <o id="773" en="You are unable to call forth your mount because your main job level is not at least ≺Possible Special Code: 12≻≺Possible Special Code: 00≻." color="1" />
+      <o id="773" en="You are unable to call forth your mount because your main job level is not at least ${number}." color="1" />
       <o id="774" en="You already possess that item and are unable to receive your just reward!" color="1" />
       <o id="775" en="A new objective has been added in the Contents &gt; Content (Ambuscade) Records of Eminence category!" color="1" />
       <o id="776" en="Additional effect: ${target} is chainbound." color="1" />
@@ -2486,6 +2486,7 @@ IN THE SOFTWARE.
       <o id="779" en="${actor} uses ${ability}.${lb}A barrier begins to pulsate around ${target}." color="1" />
       <o id="780" en="${actor} uses ${ability}.${lb}${actor} takes aim at ${target}!" color="1" />
       <o id="781" en="${target} retaliates, absorbing ${number} TP from ${actor}." color="101" />
+      <o id="792" en="${actor} uses ${spell}.${lb}${number} of ${target}'s effects disappears!" color="56" />
     </update>
   </action_messages>
 </fixes>


### PR DESCRIPTION
Adding message for dispeling more than 1 buff for players that was added with the rdm neck with dispel +1, so it works with battlemod, also fixed an error on message 773.