### PR TITLE
Adding fixes for weapon_skills and spells

### DIFF
--- a/fixes.xml
+++ b/fixes.xml
@@ -967,9 +967,7 @@
       <o id="238" duration="90" status="131" overwrites="{239}" /> <!-- Rasp -->
       <o id="239" duration="90" status="132" overwrites="{240}" /> <!-- Shock -->
       <o id="240" duration="90" status="133" overwrites="{235}" /> <!-- Drown -->
-      <o id="242" status="90" /> <!-- Absorb-ACC -->
       <o id="244" unlearnable="true" /> <!-- Meteor II -->
-      <o id="246" status="88" /> <!-- Drain II -->
       <o id="249" duration="180" status="34" /> <!-- Blaze Spikes -->
       <o id="250" duration="180" status="35" /> <!-- Ice Spikes -->
       <o id="251" duration="180" status="38" /> <!-- Shock Spikes -->
@@ -980,13 +978,6 @@
       <o id="257" status="9" unlearnable="true" /> <!-- Curse -->
       <o id="258" duration="60" status="11" /> <!-- Bind -->
       <o id="259" duration="90" status="2" overwrites="{253,273}" /> <!-- Sleep II -->
-      <o id="266" status="119" /> <!-- Absorb-STR -->
-      <o id="267" status="120" /> <!-- Absorb-DEX -->
-      <o id="268" status="121" /> <!-- Absorb-VIT -->
-      <o id="269" status="122" /> <!-- Absorb-AGI -->
-      <o id="270" status="123" /> <!-- Absorb-INT -->
-      <o id="271" status="124" /> <!-- Absorb-MND -->
-      <o id="272" status="125" /> <!-- Absorb-CHR -->
       <o id="273" duration="60" status="2" /> <!-- Sleepga -->
       <o id="274" duration="90" status="2" overwrites="{253,273}" /> <!-- Sleepga II -->
       <o id="276" duration="180" status="5" overwrites="{254,347,348,349}" /> <!-- Blind II -->
@@ -1414,7 +1405,6 @@
       <o id="877" duration="90" status="217" overwrites="{454,455,456,457,458,459,460,461,871,872,873,874,875,876,878}" /> <!-- Light Threnody II -->
       <o id="878" duration="90" status="217" overwrites="{454,455,456,457,458,459,460,461,871,872,873,874,875,876,877}" /> <!-- Dark Threnody II -->
       <o id="879" duration="300" status="597" /> <!-- Inundation -->
-      <o id="880" status="88" /> <!-- Drain III -->
       <o id="882" duration="300" status="148" overwrites="{841,842}" /> <!-- Distract III -->
       <o id="883" duration="300" status="404" overwrites="{843,844}" /> <!-- Frazzle III -->
       <o id="884" duration="180" status="21" overwrites="{286}" /> <!-- Addle II -->

--- a/fixes.xml
+++ b/fixes.xml
@@ -796,6 +796,10 @@
       <o id="224" skill="2" /> <!-- Exenterator -->
       <o id="225" skill="3" /> <!-- Chant du Cygne -->
       <o id="226" skill="3" /> <!-- Requiescat -->
+      <o id="227" skill="3" /> <!-- Knights of Rotund -->
+      <o id="228" skill="1" /> <!-- Final Paradise -->
+      <o id="229" skill="3" /> <!-- Fast Blade II -->
+      <o id="230" skill="1" /> <!-- Dragon Blow -->
       <o id="238" skill="2" /> <!-- Uriel Blade -->
       <o id="239" skill="2" /> <!-- Glory Slash -->
       <o id="240" skill="12" /> <!-- Tartarus Torpor -->
@@ -934,15 +938,15 @@
       <o id="118" duration="180" status="185" overwrites="{99,113,114,115,116,117,118,119}" /> <!-- Voidstorm -->
       <o id="119" duration="180" status="184" overwrites="{99,113,114,115,116,117,118,119}" /> <!-- Aurorastorm -->
       <o id="125" duration="1800" status="40" /> <!-- Protectra -->
-      <o id="126" duration="1800" status="40" /> <!-- Protectra II -->
-      <o id="127" duration="1800" status="40" /> <!-- Protectra III -->
-      <o id="128" duration="1800" status="40" /> <!-- Protectra IV -->
-      <o id="129" duration="1800" status="40" /> <!-- Protectra V -->
+      <o id="126" duration="1800" status="40" overwrites="{125}"/> <!-- Protectra II -->
+      <o id="127" duration="1800" status="40" overwrites="{125,126}"/> <!-- Protectra III -->
+      <o id="128" duration="1800" status="40" overwrites="{125,126,127}" /> <!-- Protectra IV -->
+      <o id="129" duration="1800" status="40" overwrites="{125,126,127,128}"/> <!-- Protectra V -->
       <o id="130" duration="1800" status="41" /> <!-- Shellra -->
-      <o id="131" duration="1800" status="41" /> <!-- Shellra II -->
-      <o id="132" duration="1800" status="41" /> <!-- Shellra III -->
-      <o id="133" duration="1800" status="41" /> <!-- Shellra IV -->
-      <o id="134" duration="1800" status="41" /> <!-- Shellra V -->
+      <o id="131" duration="1800" status="41" overwrites="{130}"/> <!-- Shellra II -->
+      <o id="132" duration="1800" status="41" overwrites="{130,131}"/> <!-- Shellra III -->
+      <o id="133" duration="1800" status="41" overwrites="{130,131,132}"/> <!-- Shellra IV -->
+      <o id="134" duration="1800" status="41" overwrites="{130,131,132,133}"/> <!-- Shellra V -->
       <o id="135" duration="3600" status="113" /> <!-- Reraise -->
       <o id="136" status="69" /> <!-- Invisible -->
       <o id="137" status="71" /> <!-- Sneak -->
@@ -963,7 +967,9 @@
       <o id="238" duration="90" status="131" overwrites="{239}" /> <!-- Rasp -->
       <o id="239" duration="90" status="132" overwrites="{240}" /> <!-- Shock -->
       <o id="240" duration="90" status="133" overwrites="{235}" /> <!-- Drown -->
+      <o id="242" status="90" /> <!-- Absorb-ACC -->
       <o id="244" unlearnable="true" /> <!-- Meteor II -->
+      <o id="246" status="88" /> <!-- Drain II -->
       <o id="249" duration="180" status="34" /> <!-- Blaze Spikes -->
       <o id="250" duration="180" status="35" /> <!-- Ice Spikes -->
       <o id="251" duration="180" status="38" /> <!-- Shock Spikes -->
@@ -974,6 +980,13 @@
       <o id="257" status="9" unlearnable="true" /> <!-- Curse -->
       <o id="258" duration="60" status="11" /> <!-- Bind -->
       <o id="259" duration="90" status="2" overwrites="{253,273}" /> <!-- Sleep II -->
+      <o id="266" status="119" /> <!-- Absorb-STR -->
+      <o id="267" status="120" /> <!-- Absorb-DEX -->
+      <o id="268" status="121" /> <!-- Absorb-VIT -->
+      <o id="269" status="122" /> <!-- Absorb-AGI -->
+      <o id="270" status="123" /> <!-- Absorb-INT -->
+      <o id="271" status="124" /> <!-- Absorb-MND -->
+      <o id="272" status="125" /> <!-- Absorb-CHR -->
       <o id="273" duration="60" status="2" /> <!-- Sleepga -->
       <o id="274" duration="90" status="2" overwrites="{253,273}" /> <!-- Sleepga II -->
       <o id="276" duration="180" status="5" overwrites="{254,347,348,349}" /> <!-- Blind II -->
@@ -1401,6 +1414,7 @@
       <o id="877" duration="90" status="217" overwrites="{454,455,456,457,458,459,460,461,871,872,873,874,875,876,878}" /> <!-- Light Threnody II -->
       <o id="878" duration="90" status="217" overwrites="{454,455,456,457,458,459,460,461,871,872,873,874,875,876,877}" /> <!-- Dark Threnody II -->
       <o id="879" duration="300" status="597" /> <!-- Inundation -->
+      <o id="880" status="88" /> <!-- Drain III -->
       <o id="882" duration="300" status="148" overwrites="{841,842}" /> <!-- Distract III -->
       <o id="883" duration="300" status="404" overwrites="{843,844}" /> <!-- Frazzle III -->
       <o id="884" duration="180" status="21" overwrites="{286}" /> <!-- Addle II -->
@@ -2825,7 +2839,7 @@
       <o id="1041" skillchain_a="Light" skillchain_b="Fusion" skillchain_c="" /> <!-- Dragon Breath -->
       <o id="1088" skillchain_a="Fusion" skillchain_b="Impaction" skillchain_c="" /> <!-- Goblin Rush -->
       <o id="1089" skillchain_a="Liquefaction" skillchain_b="" skillchain_c="" /> <!-- Bomb Toss -->
-      <o id="1090" skillchain_a="Liquefaction" skillchain_b="" skillchain_c="" /> <!-- Bomb Toss -->  
+      <o id="1090" skillchain_a="Liquefaction" skillchain_b="" skillchain_c="" /> <!-- Bomb Toss -->
       <o id="1188" skillchain_a="Light" skillchain_b="Fusion" skillchain_c="" /> <!-- Final Heaven -->
       <o id="1189" skillchain_a="Darkness" skillchain_b="Gravitation" skillchain_c="" /> <!-- Mercy Stroke -->
       <o id="1190" skillchain_a="Light" skillchain_b="Fusion" skillchain_c="" /> <!-- Knights of Round -->
@@ -3115,7 +3129,7 @@
       <o id="3687" skillchain_a="Gravitation" skillchain_b="Reverberation" skillchain_c="" /> <!-- Starward Yowl -->
       <o id="3688" skillchain_a="Light" skillchain_b="Fragmentation" skillchain_c="" /> <!-- Stalking Prey -->
       <o id="3691" skillchain_a="Fusion" skillchain_b="" skillchain_c="" /> <!-- Bludgeon -->
-	    <o id="3692" skillchain_a="Distortion" skillchain_b="" skillchain_c="" /> <!-- Deal Out -->
+      <o id="3692" skillchain_a="Distortion" skillchain_b="" skillchain_c="" /> <!-- Deal Out -->
       <o id="3699" skillchain_a="Distortion" skillchain_b="Scission" skillchain_c="" /> <!-- Expunge Magic -->
       <o id="3700" skillchain_a="Fusion" skillchain_b="Reverberation" skillchain_c="" /> <!-- Harmonic Displacement -->
       <o id="3701" skillchain_a="Fragmentation" skillchain_b="Compression" skillchain_c="" /> <!-- Sight Unseen -->
@@ -3720,6 +3734,6 @@
       <o id="253" en="Echoes of a Zephyr" />
       <o id="254" en="Griffons Never Die" />
       <o id="900" en="Distant Worlds" />
-   </update>
+    </update>
   </music>
 </fixes>


### PR DESCRIPTION
## Summary
- Adds `skills` to Knights of the Rotund, Final Paradise, Fast Blade II and Dragon Blow
- Adds `overwrites` to Protectra II - Protectra V, Shellra II - Shellra V
- Adds `status` to Drain II, Drain III, Absorb-[ACC, STR, DEX, VIT, AGI, INT, MND, CHR]
- Fixes formatting

Drain and Absorbs are a bit tricky because they add both buffs (to self) and debuffs (to the enemy). I chose to add the buff id for the buff to status since the primary intention of these spells is usually to boost the user's stats, not debuff the enemy.